### PR TITLE
Remove CentOS5 from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - >
     wget -O- bit.ly/ansibletest | env
     ANSIBLE_VERSIONS="1.4.4 1.9.2 2.1.0.0"
-    DOCKER_IMAGES="centos:5 centos:7 debian:7 fedora:20 fedora:21 fedora:24
+    DOCKER_IMAGES="centos:6 centos:7 debian:7 fedora:20 fedora:21 fedora:24
     ubuntu:12.04 ubuntu:16.04"
     sh -x
 


### PR DESCRIPTION
It is end of lifed, and its repositories are no longer up